### PR TITLE
Handle calendar call prep flow

### DIFF
--- a/client/src/pages/call-prep.test.tsx
+++ b/client/src/pages/call-prep.test.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import CallPrep from "./call-prep";
+
+(globalThis as any).React = React;
+
+const setLocationMock = vi.fn();
+const mockUseQuery = vi.fn();
+const mockUseMutation = vi.fn();
+const mutateMock = vi.fn();
+const toastMock = vi.fn();
+
+vi.mock("wouter", () => ({
+  useRoute: () => [true, { id: "calendar_event123" }],
+  useLocation: () => ["/call/calendar_event123", setLocationMock],
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: (options: any) => mockUseQuery(options),
+  useMutation: (options: any) => {
+    mockUseMutation(options);
+    return {
+      mutate: mutateMock,
+      isPending: false,
+    };
+  },
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("@/lib/queryClient", () => {
+  const setQueryData = vi.fn();
+  return {
+    apiRequest: vi.fn(),
+    queryClient: {
+      setQueryData,
+    },
+  };
+});
+
+vi.mock("@/components/ui/navigation", () => ({
+  default: () => <div data-testid="navigation" />,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("@/components/ui/card", () => ({
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  CardContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+}));
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+}));
+
+vi.mock("@/components/call-prep/executive-summary", () => ({
+  default: () => <div data-testid="executive-summary" />,
+}));
+
+vi.mock("@/components/call-prep/crm-history", () => ({
+  default: () => <div data-testid="crm-history" />,
+}));
+
+vi.mock("@/components/call-prep/competitive-landscape", () => ({
+  default: () => <div data-testid="competitive-landscape" />,
+}));
+
+vi.mock("@/components/call-prep/key-stakeholders", () => ({
+  default: () => <div data-testid="key-stakeholders" />,
+}));
+
+vi.mock("@/components/call-prep/recent-news", () => ({
+  default: () => <div data-testid="recent-news" />,
+}));
+
+vi.mock("@/components/call-prep/suggested-opportunities", () => ({
+  default: () => <div data-testid="suggested-opportunities" />,
+}));
+
+const calendarCallResponse = {
+  call: {
+    id: "call-123",
+    title: "Calendar Meeting",
+    scheduledAt: new Date("2024-05-01T12:00:00Z").toISOString(),
+    status: "upcoming",
+  },
+  company: null,
+  contacts: [],
+  callPrep: null,
+  source: "calendar" as const,
+  calendarEvent: {
+    id: "event-123",
+    summary: "Calendar Meeting",
+  },
+};
+
+describe("CallPrep calendar event flow", () => {
+  beforeEach(() => {
+    setLocationMock.mockReset();
+    mutateMock.mockReset();
+    mockUseMutation.mockReset();
+    mockUseQuery.mockImplementation((options: any) => {
+      const key = options.queryKey;
+      if (Array.isArray(key) && key[0] === "calendar-event-call") {
+        if (options.enabled === false) {
+          return { data: undefined, isLoading: false, error: null };
+        }
+        return { data: calendarCallResponse, isLoading: false, error: null };
+      }
+
+      if (Array.isArray(key) && key[0] === "/api/calls") {
+        if (!options.enabled) {
+          return { data: undefined, isLoading: false, error: null };
+        }
+        return { data: calendarCallResponse, isLoading: false, error: null };
+      }
+
+      return { data: undefined, isLoading: false, error: null };
+    });
+  });
+
+  it("shows the generate prep button after resolving a calendar-sourced call", () => {
+    const markup = renderToStaticMarkup(<CallPrep />);
+
+    expect(markup).toContain('data-testid="button-generate-prep"');
+  });
+});

--- a/server/services/integrations/salesforce.test.ts
+++ b/server/services/integrations/salesforce.test.ts
@@ -383,12 +383,15 @@ describe('SalesforceService Integration Tests', () => {
       expect(storage.getIntegrationData).toHaveBeenCalledWith('test-integration-id', 'company');
       expect(storage.getIntegrationData).toHaveBeenCalledWith('test-integration-id', 'opportunity');
 
+      const firstCallStatus = new Date('2025-02-01T10:00:00Z') > new Date() ? 'upcoming' : 'completed';
+      const secondCallStatus = new Date('2025-02-02T14:00:00Z') > new Date() ? 'upcoming' : 'completed';
+
       // Verify first call created with direct company linkage
       expect(storage.createCall).toHaveBeenCalledWith({
         companyId: 'local-company-1', // Direct from SF_ACCOUNT_1
         title: 'Demo Call with Acme',
         scheduledAt: new Date('2025-02-01T10:00:00Z'),
-        status: 'upcoming',
+        status: firstCallStatus,
         callType: 'demo',
         stage: 'initial_discovery'
       });
@@ -398,7 +401,7 @@ describe('SalesforceService Integration Tests', () => {
         companyId: 'local-company-1', // Resolved through SF_OPPORTUNITY_1 -> SF_ACCOUNT_1
         title: 'Follow-up Meeting',
         scheduledAt: new Date('2025-02-02T14:00:00Z'),
-        status: 'upcoming',
+        status: secondCallStatus,
         callType: 'follow-up',
         stage: 'initial_discovery'
       });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -65,6 +65,11 @@ export interface IStorage {
   // Integration data methods
   createIntegrationData(data: InsertIntegrationData): Promise<IntegrationData>;
   getIntegrationData(integrationId: string, dataType: string): Promise<IntegrationData[]>;
+  getIntegrationDataByExternalId(
+    integrationId: string,
+    dataType: string,
+    externalId: string
+  ): Promise<IntegrationData | undefined>;
   updateIntegrationData(id: string, updates: Partial<InsertIntegrationData>): Promise<IntegrationData>;
   deleteIntegrationData(integrationId: string, externalId: string): Promise<void>;
 
@@ -309,6 +314,23 @@ export class DatabaseStorage implements IStorage {
         eq(integrationData.integrationId, integrationId),
         eq(integrationData.dataType, dataType)
       ));
+  }
+
+  async getIntegrationDataByExternalId(
+    integrationId: string,
+    dataType: string,
+    externalId: string
+  ): Promise<IntegrationData | undefined> {
+    const [data] = await db
+      .select()
+      .from(integrationData)
+      .where(and(
+        eq(integrationData.integrationId, integrationId),
+        eq(integrationData.dataType, dataType),
+        eq(integrationData.externalId, externalId)
+      ));
+
+    return data || undefined;
   }
 
   async updateIntegrationData(id: string, updates: Partial<InsertIntegrationData>): Promise<IntegrationData> {


### PR DESCRIPTION
## Summary
- surface Google Calendar events in the dashboard with a source flag and mutation that resolves to a real call record before navigating to prep details
- teach the call prep page to translate calendar-based URLs into stored calls, reuse ensured data, and keep the generate button available for new calendar calls
- extend the backend with an ensure-call endpoint and storage helpers so calendar events map to call IDs, plus add coverage for the calendar pathway and stabilize existing tests

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d6f54697748325b8462a5f3d373489