### PR TITLE
feat: add partial prep sheet fallback

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import NotFound from "@/pages/not-found";
 import Landing from "@/pages/landing";
 import Dashboard from "@/pages/dashboard";
 import CallPrep from "@/pages/call-prep";
+import PrepSheetPage from "@/pages/prep-sheet";
 import Settings from "@/pages/settings";
 import { useAuth } from "@/hooks/useAuth";
 
@@ -22,6 +23,7 @@ function Router() {
           <Route path="/" component={Dashboard} />
           <Route path="/dashboard" component={Dashboard} />
           <Route path="/call/:id" component={CallPrep} />
+          <Route path="/prep-sheet/:eventId" component={PrepSheetPage} />
           <Route path="/settings" component={Settings} />
         </>
       )}

--- a/client/src/components/AccountSelectModal.tsx
+++ b/client/src/components/AccountSelectModal.tsx
@@ -1,0 +1,149 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+export interface AccountCandidate {
+  id: string;
+  name: string;
+  domain?: string | null;
+  confidence?: number;
+  source?: string;
+}
+
+interface AccountSelectModalProps {
+  open: boolean;
+  onClose: () => void;
+  candidates?: AccountCandidate[];
+  onSelectCandidate: (candidate: AccountCandidate) => void;
+  onSearch?: (term: string) => Promise<AccountCandidate[]>;
+  isLinking?: boolean;
+}
+
+const PERSONAL_DOMAIN_HINTS = ["gmail.com", "outlook.com", "yahoo.com"];
+
+export function AccountSelectModal({
+  open,
+  onClose,
+  candidates = [],
+  onSelectCandidate,
+  onSearch,
+  isLinking,
+}: AccountSelectModalProps) {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [searching, setSearching] = useState(false);
+  const [searchResults, setSearchResults] = useState<AccountCandidate[]>([]);
+  const [searchError, setSearchError] = useState<string | null>(null);
+
+  const showSearch = useMemo(() => candidates.length === 0 || !!onSearch, [candidates.length, onSearch]);
+
+  const candidateList = useMemo(() => {
+    if (searchResults.length > 0) {
+      return searchResults;
+    }
+    return candidates;
+  }, [candidates, searchResults]);
+
+  const handleSearch = useCallback(async () => {
+    if (!onSearch || !searchTerm.trim()) return;
+    setSearching(true);
+    setSearchError(null);
+    try {
+      const results = await onSearch(searchTerm.trim());
+      setSearchResults(results);
+    } catch (error) {
+      setSearchError((error as Error).message);
+    } finally {
+      setSearching(false);
+    }
+  }, [onSearch, searchTerm]);
+
+  return (
+    <Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && onClose()}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Select an account</DialogTitle>
+          <DialogDescription>
+            Link an account to enrich the prep sheet with CRM insights.
+          </DialogDescription>
+        </DialogHeader>
+
+        {showSearch && (
+          <div className="space-y-2">
+            <div className="flex gap-2">
+              <Input
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                placeholder="Search Salesforce accounts"
+              />
+              <Button onClick={handleSearch} disabled={!onSearch || searching}>
+                {searching ? "Searching…" : "Search"}
+              </Button>
+            </div>
+            {searchError && <p className="text-sm text-destructive">{searchError}</p>}
+            <p className="text-xs text-muted-foreground">
+              Try searching by company name or domain. Avoid personal domains like {PERSONAL_DOMAIN_HINTS.join(", ")}.
+            </p>
+          </div>
+        )}
+
+        <ScrollArea className="mt-4 h-60 pr-2">
+          <div className="space-y-3">
+            {candidateList.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                {showSearch
+                  ? "No results yet. Try searching for the account you want to link."
+                  : "No account suggestions available for this event."}
+              </p>
+            ) : (
+              candidateList.map((candidate) => (
+                <div
+                  key={candidate.id}
+                  className={cn(
+                    "rounded-lg border border-border p-3",
+                    "flex items-center justify-between gap-3",
+                  )}
+                >
+                  <div>
+                    <p className="font-medium text-sm">{candidate.name}</p>
+                    {(candidate.domain || candidate.confidence !== undefined) && (
+                      <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                        {candidate.domain && <span>{candidate.domain}</span>}
+                        {candidate.confidence !== undefined && (
+                          <Badge variant="secondary">Confidence {(candidate.confidence * 100).toFixed(0)}%</Badge>
+                        )}
+                        {candidate.source && <Badge variant="outline">{candidate.source}</Badge>}
+                      </div>
+                    )}
+                  </div>
+                  <Button
+                    size="sm"
+                    onClick={() => onSelectCandidate(candidate)}
+                    disabled={isLinking}
+                  >
+                    {isLinking ? "Linking…" : "Link"}
+                  </Button>
+                </div>
+              ))
+            )}
+          </div>
+        </ScrollArea>
+
+        <div className="flex justify-end">
+          <Button variant="ghost" onClick={onClose} disabled={isLinking}>
+            Cancel
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/features/prep-sheet/PrepSheetView.tsx
+++ b/client/src/features/prep-sheet/PrepSheetView.tsx
@@ -1,0 +1,300 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { AccountSelectModal, type AccountCandidate } from "@/components/AccountSelectModal";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+
+interface EventSummary {
+  title: string;
+  start?: string;
+  end?: string;
+  location?: string;
+}
+
+interface SheetAttendee {
+  name: string;
+  email: string;
+}
+
+interface PartialPrepSheet {
+  mode: "partial";
+  banner: string;
+  eventSummary: EventSummary;
+  attendees: SheetAttendee[];
+  organizer: SheetAttendee;
+  agendaFromInvite?: string[];
+  actionItems: string[];
+  risks: string[];
+  notesSectionFirst: true;
+}
+
+interface FullPrepSheet extends Omit<PartialPrepSheet, "mode" | "banner"> {
+  mode: "full";
+  banner?: string;
+  salesforceContext?: Record<string, unknown>;
+}
+
+export type PrepSheet = PartialPrepSheet | FullPrepSheet;
+
+interface PrepSheetResponse {
+  sheet: PrepSheet;
+  accountId?: string;
+  needsSelection?: boolean;
+  candidates?: AccountCandidate[];
+}
+
+interface PrepSheetViewProps {
+  eventId: string;
+}
+
+function formatDate(value?: string) {
+  if (!value) return "Unknown";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function AgendaList({ agenda }: { agenda?: string[] }) {
+  if (!agenda || agenda.length === 0) return null;
+  return (
+    <ul className="list-disc list-inside space-y-1 text-sm text-muted-foreground">
+      {agenda.map((item, index) => (
+        <li key={`${item}-${index}`}>{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+export function PrepSheetView({ eventId }: PrepSheetViewProps) {
+  const [sheetResponse, setSheetResponse] = useState<PrepSheetResponse | null>(null);
+  const [notes, setNotes] = useState("");
+  const [isAccountModalOpen, setIsAccountModalOpen] = useState(false);
+  const { toast } = useToast();
+
+  const generateMutation = useMutation({
+    mutationFn: async (): Promise<PrepSheetResponse> => {
+      const response = await apiRequest("POST", "/api/prep-sheet/generate", { eventId });
+      return response.json();
+    },
+    onSuccess: (data) => {
+      setSheetResponse(data);
+    },
+    onError: (error: unknown) => {
+      toast({
+        title: "Unable to generate prep sheet",
+        description: (error as Error).message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const linkAccountMutation = useMutation({
+    mutationFn: async (account: AccountCandidate) => {
+      await apiRequest("POST", "/api/prep-sheet/link-account", {
+        eventId,
+        accountId: account.id,
+      });
+    },
+    onSuccess: () => {
+      toast({
+        title: "Account linked",
+        description: "Regenerating with full context…",
+      });
+      setIsAccountModalOpen(false);
+      generateMutation.mutate();
+    },
+    onError: (error: unknown) => {
+      toast({
+        title: "Unable to link account",
+        description: (error as Error).message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  useEffect(() => {
+    if (eventId) {
+      generateMutation.mutate();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventId]);
+
+  const sheet = sheetResponse?.sheet;
+  const candidates = sheetResponse?.candidates ?? [];
+  const needsSelection = sheetResponse?.needsSelection ?? false;
+
+  const attendees = useMemo(() => sheet?.attendees ?? [], [sheet]);
+
+  if (generateMutation.isPending && !sheet) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+    );
+  }
+
+  if (!sheet) {
+    return (
+      <Card>
+        <CardContent className="py-6">
+          <p className="text-sm text-muted-foreground">No prep sheet generated yet.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const notesCard = (
+    <Card>
+      <CardHeader>
+        <CardTitle>Notes</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Textarea
+          value={notes}
+          onChange={(event) => setNotes(event.target.value)}
+          placeholder="Capture your notes for this meeting"
+          rows={6}
+        />
+      </CardContent>
+    </Card>
+  );
+
+  return (
+    <div className="space-y-6">
+      {sheet.banner && (
+        <div className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+          {sheet.banner}
+        </div>
+      )}
+
+      {sheet.notesSectionFirst ? (
+        <>{notesCard}</>
+      ) : null}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span>Event summary</span>
+            {needsSelection && (
+              <Button size="sm" onClick={() => setIsAccountModalOpen(true)}>
+                Link account to enrich
+              </Button>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          <div>
+            <p className="font-medium text-foreground">{sheet.eventSummary.title}</p>
+            <div className="mt-1 flex flex-wrap gap-2 text-muted-foreground">
+              <span>{formatDate(sheet.eventSummary.start)}</span>
+              <span>–</span>
+              <span>{formatDate(sheet.eventSummary.end)}</span>
+              {sheet.eventSummary.location && (
+                <Badge variant="outline">{sheet.eventSummary.location}</Badge>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <p className="font-medium">Organizer</p>
+            <p className="text-muted-foreground">{sheet.organizer.name || sheet.organizer.email}</p>
+          </div>
+
+          <div>
+            <p className="font-medium">Attendees</p>
+            {attendees.length === 0 ? (
+              <p className="text-muted-foreground">No attendees on this invite yet.</p>
+            ) : (
+              <ul className="mt-1 space-y-1 text-muted-foreground">
+                {attendees.map((attendee) => (
+                  <li key={`${attendee.email}-${attendee.name}`}>
+                    <span className="font-medium text-foreground">{attendee.name}</span>
+                    <span className="ml-2">{attendee.email}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div>
+            <p className="font-medium">Agenda</p>
+            <AgendaList agenda={sheet.agendaFromInvite} />
+          </div>
+        </CardContent>
+      </Card>
+
+      {(!sheet.notesSectionFirst) && notesCard}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Action items</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {sheet.actionItems.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No action items generated yet.</p>
+          ) : (
+            <ul className="list-disc list-inside text-sm text-muted-foreground">
+              {sheet.actionItems.map((item, index) => (
+                <li key={`${item}-${index}`}>{item}</li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Risks</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {sheet.risks.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No risks identified yet.</p>
+          ) : (
+            <ul className="list-disc list-inside text-sm text-muted-foreground">
+              {sheet.risks.map((item, index) => (
+                <li key={`${item}-${index}`}>{item}</li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <AccountSelectModal
+        open={isAccountModalOpen}
+        onClose={() => setIsAccountModalOpen(false)}
+        candidates={candidates}
+        onSelectCandidate={(candidate) => linkAccountMutation.mutate(candidate)}
+        isLinking={linkAccountMutation.isPending}
+      />
+
+      {sheet.mode === "full" && sheet.salesforceContext && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Salesforce context</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ScrollArea className="h-40">
+              <pre className="text-xs text-muted-foreground whitespace-pre-wrap">
+                {JSON.stringify(sheet.salesforceContext, null, 2)}
+              </pre>
+            </ScrollArea>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/prep-sheet.tsx
+++ b/client/src/pages/prep-sheet.tsx
@@ -1,0 +1,30 @@
+import Navigation from "@/components/ui/navigation";
+import { PrepSheetView } from "@/features/prep-sheet/PrepSheetView";
+import { useRoute } from "wouter";
+import { Card, CardContent } from "@/components/ui/card";
+
+export default function PrepSheetPage() {
+  const [, params] = useRoute("/prep-sheet/:eventId");
+  const eventId = params?.eventId;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation />
+      <div className="p-6">
+        <div className="mx-auto max-w-5xl space-y-6">
+          {eventId ? (
+            <PrepSheetView eventId={eventId} />
+          ) : (
+            <Card>
+              <CardContent className="py-6">
+                <p className="text-muted-foreground">
+                  Select a calendar event to generate a prep sheet.
+                </p>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -7,11 +7,14 @@ import { insertCompanySchema, insertContactSchema, insertCallSchema, insertCallP
 import { integrationManager } from "./services/integrations/manager";
 import { CryptoService } from "./services/crypto";
 import { z } from "zod";
+import { prepSheetRouter } from "./routes/prepSheet";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   // Setup Replit Auth (Google Sign-in support)
   await setupAuth(app);
-  
+
+  app.use(prepSheetRouter);
+
 
   // Auth routes
   app.get('/api/auth/user', isAuthenticated, async (req: any, res) => {

--- a/server/routes/prepSheet.ts
+++ b/server/routes/prepSheet.ts
@@ -1,0 +1,204 @@
+import { Router } from "express";
+import { z } from "zod";
+import { isAuthenticated } from "../replitAuth";
+import { GoogleCalendarService, type CalendarEvent } from "../services/googleCalendar";
+import { resolveAccountForEvent } from "../services/accountResolver";
+import { storage } from "../storage";
+import { log } from "../vite";
+
+const calendarService = new GoogleCalendarService();
+
+const generateSchema = z.object({
+  eventId: z.string().min(1, "eventId is required"),
+});
+
+const linkAccountSchema = z.object({
+  eventId: z.string().min(1, "eventId is required"),
+  accountId: z.string().min(1, "accountId is required"),
+});
+
+function normaliseDateInput(date?: { dateTime?: string; date?: string }): string | undefined {
+  if (!date) return undefined;
+  if (date.dateTime) return date.dateTime;
+  if (date.date) {
+    const parsed = new Date(date.date);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString();
+    }
+  }
+  return undefined;
+}
+
+function parseAgenda(description?: string | null): string[] | undefined {
+  if (!description) return undefined;
+
+  const lines = description
+    .split(/\r?\n/)
+    .map(line => line.replace(/^\s*([*\-•])\s*/, "").trim())
+    .filter(Boolean);
+
+  if (lines.length === 0) {
+    return undefined;
+  }
+
+  return lines.slice(0, 12);
+}
+
+function buildEventContext(event: CalendarEvent) {
+  return {
+    eventSummary: {
+      title: event.summary || "Untitled event",
+      start: normaliseDateInput(event.start),
+      end: normaliseDateInput(event.end),
+      location: event.location ?? undefined,
+    },
+    attendees: (event.attendees || []).map(attendee => ({
+      name: attendee.displayName ?? attendee.email ?? "",
+      email: attendee.email ?? "",
+    })),
+    organizer: {
+      name: event.organizer?.displayName ?? event.organizer?.email ?? "",
+      email: event.organizer?.email ?? "",
+    },
+    agendaFromInvite: parseAgenda(event.description),
+  };
+}
+
+function buildPartialSheet(event: CalendarEvent, options?: { includeAttendeesWarning?: boolean }) {
+  const base = buildEventContext(event);
+  const bannerMessages = [
+    "Limited context: no account linked yet. You can link an account to enrich this sheet.",
+  ];
+
+  if (options?.includeAttendeesWarning) {
+    bannerMessages.push("No attendees found on the invite. Add invitees or link an account for more context.");
+  }
+
+  return {
+    mode: "partial" as const,
+    banner: bannerMessages.join(" "),
+    ...base,
+    actionItems: [] as string[],
+    risks: [] as string[],
+    notesSectionFirst: true,
+  };
+}
+
+function buildFullSheet(event: CalendarEvent, account: { id: string; name?: string | null; domain?: string | null }) {
+  const base = buildEventContext(event);
+  return {
+    mode: "full" as const,
+    ...base,
+    actionItems: [] as string[],
+    risks: [] as string[],
+    notesSectionFirst: true,
+    salesforceContext: {
+      account,
+    },
+  };
+}
+
+export const prepSheetRouter = Router();
+
+prepSheetRouter.post("/api/prep-sheet/generate", isAuthenticated, async (req: any, res, next) => {
+  try {
+    const { eventId } = generateSchema.parse(req.body ?? {});
+    const userId = req.user?.claims?.sub;
+
+    if (!userId) {
+      return res.status(401).json({ message: "Unauthorized" });
+    }
+
+    const event = await calendarService.getEventById(userId, eventId);
+
+    if (!event) {
+      return res.status(404).json({ message: "Event not found" });
+    }
+
+    const attendees = event.attendees || [];
+
+    const existingLink = await storage.getEventAccountLink(userId, eventId);
+
+    if (existingLink) {
+      const sheet = buildFullSheet(event, {
+        id: existingLink.accountId,
+      });
+
+      log(
+        `prep-sheet generation complete mode=full resolver=linked candidateCount=0 eventId=${eventId}`,
+        "prep-sheet",
+      );
+
+      return res.json({
+        sheet,
+        accountId: existingLink.accountId,
+      });
+    }
+
+    const resolution = await resolveAccountForEvent(userId, event);
+
+    if (resolution.resolvedAccount && resolution.confidence >= 0.9) {
+      const sheet = buildFullSheet(event, {
+        id: resolution.resolvedAccount.id,
+        name: resolution.resolvedAccount.name,
+        domain: resolution.resolvedAccount.domain,
+      });
+
+      log(
+        `prep-sheet generation complete mode=full resolver=${resolution.outcome} candidateCount=${resolution.candidates.length} eventId=${eventId}`,
+        "prep-sheet",
+      );
+
+      return res.json({
+        sheet,
+        accountId: resolution.resolvedAccount.id,
+        candidates: resolution.candidates.slice(0, 3),
+      });
+    }
+
+    const partialSheet = buildPartialSheet(event, {
+      includeAttendeesWarning: attendees.length === 0,
+    });
+
+    const candidates = resolution.candidates.slice(0, 3);
+    const needsSelection = true;
+
+    log(
+      `prep-sheet generation complete mode=partial resolver=${resolution.outcome} candidateCount=${candidates.length} eventId=${eventId}`,
+      "prep-sheet",
+    );
+
+    return res.json({
+      sheet: partialSheet,
+      needsSelection,
+      candidates,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+prepSheetRouter.post("/api/prep-sheet/link-account", isAuthenticated, async (req: any, res, next) => {
+  try {
+    const { eventId, accountId } = linkAccountSchema.parse(req.body ?? {});
+    const userId = req.user?.claims?.sub;
+
+    if (!userId) {
+      return res.status(401).json({ message: "Unauthorized" });
+    }
+
+    const link = await storage.upsertEventAccountLink({
+      userId,
+      eventId,
+      accountId,
+    });
+
+    log(`prep-sheet event linked eventId=${eventId} accountId=${accountId}`, "prep-sheet");
+
+    res.json({
+      link,
+    });
+  } catch (error) {
+    next(error);
+  }
+});

--- a/server/services/accountResolver.ts
+++ b/server/services/accountResolver.ts
@@ -1,0 +1,93 @@
+import { storage } from "../storage";
+import type { CalendarEvent } from "./googleCalendar";
+
+const PERSONAL_DOMAINS = new Set([
+  "gmail.com",
+  "outlook.com",
+  "yahoo.com",
+  "hotmail.com",
+  "icloud.com",
+  "aol.com",
+  "protonmail.com",
+]);
+
+export interface AccountCandidate {
+  id: string;
+  name: string;
+  domain?: string | null;
+  confidence: number;
+  source: "domain" | "name";
+}
+
+export interface AccountResolutionResult {
+  resolvedAccount?: AccountCandidate;
+  confidence: number;
+  candidates: AccountCandidate[];
+  outcome: "resolved" | "candidates" | "none";
+}
+
+function extractDomain(email?: string | null): string | null {
+  if (!email || !email.includes("@")) return null;
+  const [, domain] = email.split("@");
+  const lowerDomain = domain.toLowerCase();
+  if (PERSONAL_DOMAINS.has(lowerDomain)) {
+    return null;
+  }
+  return lowerDomain;
+}
+
+export async function resolveAccountForEvent(
+  _userId: string,
+  event: CalendarEvent,
+): Promise<AccountResolutionResult> {
+  const attendees = event.attendees || [];
+  const domainMatches = new Map<string, AccountCandidate>();
+
+  for (const attendee of attendees) {
+    const domain = extractDomain(attendee.email);
+    if (!domain) continue;
+    if (domainMatches.has(domain)) continue;
+
+    const company = await storage.getCompanyByDomain(domain);
+    if (!company) continue;
+
+    domainMatches.set(domain, {
+      id: company.id,
+      name: company.name,
+      domain: company.domain,
+      confidence: 0.85,
+      source: "domain",
+    });
+  }
+
+  const candidates = Array.from(domainMatches.values());
+
+  if (candidates.length === 0) {
+    return {
+      resolvedAccount: undefined,
+      confidence: 0,
+      candidates: [],
+      outcome: "none",
+    };
+  }
+
+  candidates.sort((a, b) => b.confidence - a.confidence);
+
+  if (candidates.length === 1) {
+    const [candidate] = candidates;
+    candidate.confidence = Math.max(candidate.confidence, 0.92);
+    return {
+      resolvedAccount: candidate,
+      confidence: candidate.confidence,
+      candidates,
+      outcome: "resolved",
+    };
+  }
+
+  return {
+    resolvedAccount: undefined,
+    confidence: candidates[0]?.confidence ?? 0,
+    candidates,
+    outcome: "candidates",
+  };
+}


### PR DESCRIPTION
## Summary
- add dedicated prep sheet routes that build partial sheets when no account is linked and expose manual linking
- persist event-to-account links and surface simple account resolution candidates
- introduce prep sheet UI with limited-context rendering, account selection modal, and routing entry point

## Testing
- npm run check *(fails: existing type errors in project)*

------
https://chatgpt.com/codex/tasks/task_e_68d70095e1188325ae223c33fb41bb62