### PR TITLE
Route calendar calls through prep sheet flow

### DIFF
--- a/client/src/pages/call-prep.test.tsx
+++ b/client/src/pages/call-prep.test.tsx
@@ -62,6 +62,17 @@ vi.mock("@/components/ui/skeleton", () => ({
   Skeleton: ({ children, ...props }: any) => <div {...props}>{children}</div>,
 }));
 
+vi.mock("@/components/ui/sheet", () => ({
+  Sheet: ({ children }: any) => <div data-testid="sheet-mock">{children}</div>,
+  SheetContent: ({ children }: any) => <div data-testid="sheet-content-mock">{children}</div>,
+  SheetHeader: ({ children }: any) => <div data-testid="sheet-header-mock">{children}</div>,
+  SheetTitle: ({ children }: any) => <div data-testid="sheet-title-mock">{children}</div>,
+}));
+
+vi.mock("@/features/prep-sheet/PrepSheetView", () => ({
+  PrepSheetView: ({ eventId }: any) => <div data-testid="prep-sheet-view">{eventId}</div>,
+}));
+
 vi.mock("@/components/call-prep/executive-summary", () => ({
   default: () => <div data-testid="executive-summary" />,
 }));
@@ -128,9 +139,12 @@ describe("CallPrep calendar event flow", () => {
     });
   });
 
-  it("shows the generate prep button after resolving a calendar-sourced call", () => {
+  it("renders the prep sheet flow for calendar-sourced calls", () => {
     const markup = renderToStaticMarkup(<CallPrep />);
 
-    expect(markup).toContain('data-testid="button-generate-prep"');
+    expect(markup).toContain('data-testid="prep-sheet-view"');
+    expect(markup).toMatch(/event-?123/);
+    expect(markup).toContain('data-testid="button-open-prep-sheet"');
+    expect(markup).not.toContain('data-testid="button-generate-prep"');
   });
 });


### PR DESCRIPTION
## Summary
- route calendar-sourced calls in `call-prep` through the new `PrepSheetView`, automatically surfacing it in a sheet with a CTA in the header
- guard legacy prep generation so it only runs when CRM context exists and keep the old layout for CRM-backed calls
- update the call prep page test to cover the new prep sheet behaviour

## Testing
- npx vitest run client/src/pages/call-prep.test.tsx
- npm run check *(fails: existing server typing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68d70aabc42083259af618ab7bf41b85